### PR TITLE
SQL 2005 compatibility

### DIFF
--- a/RequestReduce/Nuget/Tools/RequestReduceFiles.sql
+++ b/RequestReduce/Nuget/Tools/RequestReduceFiles.sql
@@ -5,7 +5,7 @@
 	[Content] [varbinary](max) NOT NULL,
 	[OriginalName] [nvarchar](max) NULL,
 	[IsExpired] [bit] NOT NULL,
-	[LastUpdated] [datetime2](7) NOT NULL,
+	[LastUpdated] [datetime] NOT NULL,
 PRIMARY KEY CLUSTERED 
 (
 	[RequestReduceFileId] ASC

--- a/RequestReduce/Store/RequestReduceContext.cs
+++ b/RequestReduce/Store/RequestReduceContext.cs
@@ -31,7 +31,7 @@ namespace RequestReduce.Store
                 modelBuilder.Entity<RequestReduceFile>()
                     .Property(s => s.LastUpdated)
                     .IsRequired()
-                    .HasColumnType("datetime2");
+                    .HasColumnType("datetime");
 
                 modelBuilder.Entity<RequestReduceFile>()
                     .Property(s => s.Content)


### PR DESCRIPTION
Previously, the datetime2 field in the sql script prevented the sql storage for people running SQL 2005. I changed everything to datetime, giving compatibility. If you want to keep datetime2 for SQL 2008, let me know, and maybe we can add a configuration setting that will allow a user to select when they are running 2005.
