### PR TITLE
possible fix for 82 Response filter is not valid error

### DIFF
--- a/RequestReduce.Facts/Module/RequestReduceModuleFacts.cs
+++ b/RequestReduce.Facts/Module/RequestReduceModuleFacts.cs
@@ -41,7 +41,7 @@ namespace RequestReduce.Facts.Module
         }
 
         [Fact]
-        public void WillSetResponseFilterIfHtmlContent()
+        public void WillGetAndSetResponseFilterIfHtmlContent()
         {
             var module = new RequestReduceModule();
             var context = new Mock<HttpContextBase>();
@@ -60,6 +60,7 @@ namespace RequestReduce.Facts.Module
 
             module.InstallFilter(context.Object);
 
+            context.VerifyGet(x => x.Response.Filter, Times.Once());
             context.VerifySet(x => x.Response.Filter = It.IsAny<Stream>(), Times.Once());
             RRContainer.Current = null;
         }

--- a/RequestReduce/Module/RequestReduceModule.cs
+++ b/RequestReduce/Module/RequestReduceModule.cs
@@ -233,6 +233,8 @@ namespace RequestReduce.Module
 
             if(string.IsNullOrEmpty(config.SpritePhysicalPath))
                 config.SpritePhysicalPath = context.Server.MapPath(config.SpriteVirtualPath);
+
+            var oldFilter = context.Response.Filter;
             context.Response.Filter = RRContainer.Current.GetInstance<AbstractFilter>();
             context.Items.Add(CONTEXT_KEY, new object());
             RRTracer.Trace("Attaching Filter to {0}", request.RawUrl);


### PR DESCRIPTION
I did some research into this issue and it looks the same as this [reported in this blog post](https://github.com/mwrock/RequestReduce/issues/82). It seems there is a bug in ASP.NET 3.5 where you must read the response filter before you set it.

 I create a pull request with this fix however I was unable to repro the error so I cannot verify the fix definitely works.
