### PR TITLE
Use CredentialCache.DefaultCredentials on WebRequest and WebProxy

### DIFF
--- a/RequestReduce/Utilities/WebClientWrapper.cs
+++ b/RequestReduce/Utilities/WebClientWrapper.cs
@@ -45,6 +45,7 @@ namespace RequestReduce.Utilities
             try
             {
                 var client = WebRequest.Create(url);
+                client.Credentials = CredentialCache.DefaultCredentials;
                 var systemWebProxy = WebRequest.GetSystemWebProxy();
                 systemWebProxy.Credentials = CredentialCache.DefaultCredentials;
                 client.Proxy = systemWebProxy;


### PR DESCRIPTION
I made this change to get RequestReduce working on a website using Windows authentication. Without it I was I was getting 401 errors back.
