### PR TITLE
I had a strange issue when using jQuery.load.  This fixed it locally.

### DIFF
--- a/RequestReduce/Store/LocalDiskStore.cs
+++ b/RequestReduce/Store/LocalDiskStore.cs
@@ -155,7 +155,14 @@ namespace RequestReduce.Store
             var fileName = url.ToLower();
             if (!string.IsNullOrEmpty(configuration.ContentHost))
                 fileName = fileName.Replace(configuration.ContentHost.ToLower(), "");
-            return fileName.Replace(configuration.SpriteVirtualPath.ToLower(), configuration.SpritePhysicalPath.ToLower()).Replace('/', '\\');
+            fileName = fileName.Replace(configuration.SpriteVirtualPath.ToLower(), configuration.SpritePhysicalPath.ToLower()).Replace('/', '\\');
+             
+            //strip all query parameters 
+            var index = fileName.IndexOf('?');
+            if(index > 0)
+                fileName = fileName.Substring(0, index);
+
+            return fileName;
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
Hey guys, Awesome project!!!

Without going into too much of the 'why'... 

I am loading content via jQuery.load.  Within this content (not in a <head> tag because it's only partial content), there are script tags.  RequestReduce combines them into one file like I would expect.  However jQuery seems to by modifying the http request url and adding "?_=1327618241109" to any content that is loaded via .load.  (note, it doesn't not add it to my partial content request, it adds it to the script GET request)  I only added code to remove everything after the first '?' character....perhaps any illegal characters should be removed?

Here is where I learned a bit about the strange underscore character:
http://stackoverflow.com/questions/3687729/who-add-single-underscore-query-parameter

The script tag looks like this:

<script src="/RequestReduceContent/610d2c2aa901bcf1bbdc2ca173be017b-91020c5cf86c4891c372ae53473cfc12-RequestReducedScript.js" type="text/javascript" ></script>


Yet the request from the browser (I've also double checked Fiddler) looks like this:
http://localhost/RequestReduceContent/610d2c2aa901bcf1bbdc2ca173be017b-91020c5cf86c4891c372ae53473cfc12-RequestReducedScript.js?_=1327690666263

Other options I had were to use jQuery's getScript, but then RequestReduce doesn't run on the script.
I could have also used "RRFilter" but again, then I can't take advantage of RequestReduce.

Regards,
Chris
