### PR TITLE
Added Ability to Transform Generated FileName

### DIFF
--- a/RequestReduce/Api/Registry.cs
+++ b/RequestReduce/Api/Registry.cs
@@ -15,7 +15,7 @@ namespace RequestReduce.Api
 
         public delegate string UrlTransformFunc(string originalabsoluteUrl, string urlWithContentHost);
         public delegate string ContextUrlTransformFunc(HttpContextBase httpRequest, string originalabsoluteUrl, string urlWithContentHost);
-        public delegate string ResourceFileNameTransformerFunc(string originalFileName);
+        public delegate string ResourceFileNameTransformerFunc();
         [Obsolete("Use RequestReduce.Api.Registry.UrlTransformer")]
         public static UrlTransformFunc AbsoluteUrlTransformer { get; set; }
         public static ContextUrlTransformFunc UrlTransformer { get; set; }

--- a/RequestReduce/ResourceTypes/CssResource.cs
+++ b/RequestReduce/ResourceTypes/CssResource.cs
@@ -14,12 +14,12 @@ namespace RequestReduce.ResourceTypes
         {
             get
             {
-                String originalFileName = "RequestReducedScript.css";
+                
                 if (Registry.FileNameTransformer != null)
                 {
-                    return Registry.FileNameTransformer(originalFileName);
+                    return String.Format("{0}RequestReducedStyle{0}.css", Registry.FileNameTransformer());
                 }
-                return originalFileName;
+                return "RequestReducedStyle.css";
             }
         }
 

--- a/RequestReduce/ResourceTypes/JavaScriptResource.cs
+++ b/RequestReduce/ResourceTypes/JavaScriptResource.cs
@@ -26,12 +26,11 @@ namespace RequestReduce.ResourceTypes
         {
             get 
             {
-                String originalFileName =  "RequestReducedScript.js";
                 if (Registry.FileNameTransformer != null)
                 {
-                    return Registry.FileNameTransformer(originalFileName);
+                    return String.Format("{0}RequestReducedScript.js", Registry.FileNameTransformer());
                 }
-                return originalFileName;
+                return "RequestReducedScript.js";
             }
         }
 


### PR DESCRIPTION
This will allow people to extend the file path out with any kind of custom behavior that they want
withtout breaking the hash lookup.

An example of how this can be done in a Global.asax file to add a timestamp when the uri is generated to cause cache invalidation for people who don't have a good scheme in place to modify file names.

Registry.FileNameTransformer = (original) =>
                 {
                     var originalExtension = original.Split(new char[] {'.'})[1];
                     return String.Format("RequestReduce{0}.{1}", DateTime.Now.Ticks ,originalExtension);
                 };
