### PR TITLE
Empty Constuctor

### DIFF
--- a/RequestReduce.SassLessCoffee/LessHandler.cs
+++ b/RequestReduce.SassLessCoffee/LessHandler.cs
@@ -12,6 +12,11 @@ namespace RequestReduce.SassLessCoffee
         private readonly IFileWrapper fileWrapper;
         private readonly ILessEngine engine;
 
+        public LessHandler() : this(new FileWrapper())
+        {
+            
+        }
+
         public LessHandler(IFileWrapper fileWrapper)
         {
             this.fileWrapper = fileWrapper;


### PR DESCRIPTION
With Orchard, the bootstrapper stuff doesn't work, not sure if you want to take a look?

But for this workaround or fix (you decide :) ) I added an empty constructor, so I can add it into the web.config where I usually would add a dotless handler. This allows it to be hooked up and thus added to the minified .css files.
